### PR TITLE
ci: automatically cleanup database branches after pull request closes

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,15 @@
+name: Clean up Preview Deployment
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Neon Branch
+        uses: neondatabase/delete-branch-action@v3.1.3
+        with:
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
+          branch: preview/pr-${{ github.event.number }}-${{ github.event.pull_request.head.ref }}
+          api_key: ${{ secrets.NEON_API_KEY }}

--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -6,10 +6,12 @@ on:
 jobs:
   delete-preview:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Delete Neon Branch
         uses: neondatabase/delete-branch-action@v3.1.3
         with:
           project_id: ${{ secrets.NEON_PROJECT_ID }}
-          branch: preview/pr-${{ github.event.number }}-${{ github.event.pull_request.head.ref }}
+          branch: preview/${{ github.event.pull_request.head.ref }}
           api_key: ${{ secrets.NEON_API_KEY }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the cleanup of preview deployments when a pull request is closed.

### New workflow addition:

* [`.github/workflows/cleanup-preview.yml`](diffhunk://#diff-9f8b1b985971f1739316f825a618757d4aef109dcdc581cfe7a80c83f9d13a5bR1-R15): Added a workflow named "Clean up Preview Deployment" that triggers on pull request closure. It uses the `neondatabase/delete-branch-action` to delete a Neon branch associated with the preview deployment, utilizing `NEON_PROJECT_ID` and `NEON_API_KEY` secrets for authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced an automated workflow to clean up preview deployments when pull requests are closed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->