### PR TITLE
fix: remove read-only constraint

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -6,8 +6,6 @@ on:
 jobs:
   delete-preview:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - name: Delete Neon Branch
         uses: neondatabase/delete-branch-action@v3.1.3


### PR DESCRIPTION
This pull request simplifies the GitHub Actions workflow by removing unnecessary permissions from the `delete-preview` job.

Workflow cleanup:

* [`.github/workflows/cleanup-preview.yml`](diffhunk://#diff-9f8b1b985971f1739316f825a618757d4aef109dcdc581cfe7a80c83f9d13a5bL9-L10): Removed the `permissions` block specifying `contents: read` from the `delete-preview` job, as it is not required for the `delete-branch-action`.