### PR TITLE
ci: remove push trigger on CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
-
   pull_request:
     branches:
       - main


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/ci.yml` to simplify the event triggers for the CI pipeline.

Workflow trigger changes:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL4-L7): Removed the `push` event trigger for the `main` branch, leaving only the `pull_request` event trigger for the `main` branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to run only on pull requests targeting the main branch, no longer triggering on direct pushes to main.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->